### PR TITLE
RC-21095 - Term highlight cycling selecting incorrect first result

### DIFF
--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -1090,10 +1090,11 @@ class PDFFindController {
     const offset = this._offset;
     const numMatches = this.#getMatchCount(matches, highlights);
     const previous = this.#state.findPrevious;
+    const firstMatchIdx = this.#state.jumpToFirstHighlight ? 0 : -1;
 
     if (numMatches) {
       // There were matches for the page, so initialize `matchIdx`.
-      offset.matchIdx = previous ? numMatches - 1 : 0;
+      offset.matchIdx = previous ? numMatches - 1 : firstMatchIdx;
       this.#updateMatch(/* found = */ true);
       return true;
     }


### PR DESCRIPTION
RC-21095

Fixes a bug that incorrectly selects the second term hit when the user setting 'Jump to First Highlight' is off