### PR TITLE
Return a `PasswordException` if 403 status is caught

### DIFF
--- a/src/display/network_utils.js
+++ b/src/display/network_utils.js
@@ -88,7 +88,7 @@ function createResponseStatusError(status, url) {
   if (status === 404 || (status === 0 && url.startsWith("file:"))) {
     return new MissingPDFException('Missing PDF "' + url + '".');
   } else if (status === 403) {
-    return new PasswordException("Document is password protected", "");
+    return new PasswordException("Document is password protected!", "");
   }
   return new UnexpectedResponseException(
     `Unexpected server response (${status}) while retrieving PDF "${url}".`,

--- a/src/display/network_utils.js
+++ b/src/display/network_utils.js
@@ -16,6 +16,7 @@
 import {
   assert,
   MissingPDFException,
+  PasswordException,
   UnexpectedResponseException,
 } from "../shared/util.js";
 import { getFilenameFromContentDispositionHeader } from "./content_disposition.js";
@@ -86,6 +87,8 @@ function extractFilenameFromHeader(getResponseHeader) {
 function createResponseStatusError(status, url) {
   if (status === 404 || (status === 0 && url.startsWith("file:"))) {
     return new MissingPDFException('Missing PDF "' + url + '".');
+  } else if (status === 403) {
+    return new PasswordException("Document is password protected", "");
   }
   return new UnexpectedResponseException(
     `Unexpected server response (${status}) while retrieving PDF "${url}".`,

--- a/src/display/network_utils.js
+++ b/src/display/network_utils.js
@@ -88,7 +88,7 @@ function createResponseStatusError(status, url) {
   if (status === 404 || (status === 0 && url.startsWith("file:"))) {
     return new MissingPDFException('Missing PDF "' + url + '".');
   } else if (status === 403) {
-    return new PasswordException("Document is password protected!", "");
+    return new PasswordException("Document is password protected", "");
   }
   return new UnexpectedResponseException(
     `Unexpected server response (${status}) while retrieving PDF "${url}".`,


### PR DESCRIPTION
used to handle cases where a locked document is attempted to be retrieved. A `PasswordException` will be returned opposed to an `UnexpectedResponseException`