### PR TITLE
Rr 22654 fuzzy search optimization

### DIFF
--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -964,7 +964,7 @@ class PDFFindController {
             0.2
           );
           console.timeEnd("findSubstringMatches");
-          console.log(tssMatches.length, "tss matches found at threshold");
+          console.log(tssMatches.length, "tss matches found at threshold 0.2");
 
           const bestMatch = tssMatches[0];
           if (!bestMatch) {
@@ -1107,18 +1107,19 @@ class PDFFindController {
     let highestScore = 0;
 
     const [normalizedQuery] = normalize(query);
+    const queryLength = query.split(/\s+/).length;
 
     console.log(
       "Trying",
-      Math.floor((query.length * 2 - query.length * 0.5) / 3),
-      "substrings for query of length",
-      query.length
+      Math.floor((queryLength * 2 - queryLength * 0.5) / 3),
+      "substring lengths for query of length",
+      queryLength
     );
 
     for (let i = 0; i < textWords.length; i += coarseness) {
       for (
-        let j = Math.floor(i + query.length * 0.5);
-        j <= textWords.length && j - i <= query.length * 2;
+        let j = Math.floor(i + queryLength * 0.5);
+        j <= textWords.length && j - i <= queryLength * 2;
         j += coarseness
       ) {
         const phrase = textWords.slice(i, j).join(" ");

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -912,7 +912,7 @@ class PDFFindController {
       this._pageMatches[pageIndex]?.length > 0 ||
       this.pageHighlights[pageIndex]?.length > 0;
 
-    for (let threshold = 0.3; threshold >= 0.2; threshold -= 0.1) {
+    for (let threshold = 0.3; threshold >= 0.2; threshold -= 0.05) {
       if (
         !this.#fuzzyMatchFound &&
         !hasMatches &&
@@ -1119,7 +1119,7 @@ class PDFFindController {
   //   return highestScore > 0.3 ? bestMatch : null;
   // }
 
-  #findGoodSubstringMatch(text, query, precision) {
+  #findGoodSubstringMatch(text, query, coarseness) {
     console.time("findGoodSubstringMatch");
     if (!text || !query) {
       return null;
@@ -1132,11 +1132,11 @@ class PDFFindController {
 
     const [normalizedQuery] = normalize(query);
 
-    for (let i = 0; i < textWords.length; i += precision) {
+    for (let i = 0; i < textWords.length; i += coarseness) {
       for (
         let j = i + 3;
         j <= textWords.length && j - i <= 40;
-        j += precision
+        j += coarseness
       ) {
         const phrase = textWords.slice(i, j).join(" ");
         const [normalizedPhrase] = normalize(phrase);

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -969,7 +969,7 @@ class PDFFindController {
           }
 
           const bestWindowText = bestMatch.item.text;
-          const bestSubstring = this.#findGoodSubstringMatch(
+          const bestSubstring = this.#findBestSubstringMatch(
             bestWindowText,
             cleanedQuery
           );
@@ -1056,7 +1056,7 @@ class PDFFindController {
     return fuzzyMatches.sort((a, b) => b.score - a.score);
   }
 
-  #findGoodSubstringMatch(text, query) {
+  #findBestSubstringMatch(text, query) {
     if (!text || !query) {
       return null;
     }

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -913,125 +913,133 @@ class PDFFindController {
       this._pageMatches[pageIndex]?.length > 0 ||
       this.pageHighlights[pageIndex]?.length > 0;
 
-    if (
-      !this.#fuzzyMatchFound &&
-      !hasMatches &&
-      fuzzySearchEnabled &&
-      query.length > 1
-    ) {
-      this._pdfDocument
-        .getPage(pageIndex + 1)
-        .then(pdfPage => pdfPage.getTextContent({ disableNormalization: true }))
-        .then(textContent => {
-          const originalTextItems = textContent.items
-            .map(item => item.str)
-            .filter(originalTextItem => originalTextItem !== "");
-          const items = [];
+    for (let threshold = 0.9; threshold >= 0.3; threshold -= 0.2) {
+      if (
+        !this.#fuzzyMatchFound &&
+        !hasMatches &&
+        fuzzySearchEnabled &&
+        query.length > 1
+      ) {
+        this._pdfDocument
+          .getPage(pageIndex + 1)
+          .then(pdfPage =>
+            pdfPage.getTextContent({ disableNormalization: true })
+          )
+          .then(textContent => {
+            const originalTextItems = textContent.items
+              .map(item => item.str)
+              .filter(originalTextItem => originalTextItem !== "");
+            const items = [];
 
-          originalTextItems.forEach((item, index) => {
-            if (
-              item.length === 1 ||
-              originalTextItems[index - 1]?.length === 1
-            ) {
-              if (items.length > 0) {
-                items[items.length - 1] = `${items.at(-1)}${item}`;
+            originalTextItems.forEach((item, index) => {
+              if (
+                item.length === 1 ||
+                originalTextItems[index - 1]?.length === 1
+              ) {
+                if (items.length > 0) {
+                  items[items.length - 1] = `${items.at(-1)}${item}`;
+                } else {
+                  items.push(item);
+                }
               } else {
                 items.push(item);
               }
-            } else {
-              items.push(item);
-            }
-          });
-
-          console.log("items:" + items);
-
-          const cleanedQuery = query.replaceAll(/\.{3,}/g, "").trim();
-
-          const windowSize = 5;
-          const step = 1;
-          const slidingChunks = [];
-
-          for (let i = 0; i <= items.length - windowSize; i += step) {
-            const windowChunks = items.slice(i, i + windowSize);
-            slidingChunks.push({
-              text: windowChunks.join("\n"),
-              indices: [i, i + windowSize - 1],
-              items: windowChunks,
             });
-          }
 
-          const fuse = new Fuse(slidingChunks, {
-            keys: ["text"],
-            includeScore: true,
-            threshold: 0.3,
-            ignoreLocation: true,
-            distance: 100,
-            minMatchCharLength: 3,
+            console.log("items:", items);
+
+            const cleanedQuery = query.replaceAll(/\.{3,}/g, "").trim();
+
+            const windowSize = 5;
+            const step = 1;
+            const slidingChunks = [];
+
+            for (let i = 0; i <= items.length - windowSize; i += step) {
+              const windowChunks = items.slice(i, i + windowSize);
+              slidingChunks.push({
+                text: windowChunks.join("\n"),
+                indices: [i, i + windowSize - 1],
+                items: windowChunks,
+              });
+            }
+
+            const fuse = new Fuse(slidingChunks, {
+              keys: ["text"],
+              includeScore: true,
+              threshold,
+              ignoreLocation: true,
+              distance: 100,
+              minMatchCharLength: 3,
+              shouldSort: true,
+            });
+
+            const fuzzyMatches = fuse.search(cleanedQuery);
+            console.log(
+              fuzzyMatches.length,
+              "matches found at threshold:",
+              threshold
+            );
+
+            console.log("best match:", fuzzyMatches[0]);
+            const bestMatch = fuzzyMatches[0];
+            if (!bestMatch) {
+              return;
+            }
+
+            const bestWindowText = bestMatch.item.text;
+            console.log("bestWindowText:", bestWindowText);
+            // console.time("Original");
+            const bestSubstring = this.#findBestSubstringMatch(
+              bestWindowText,
+              cleanedQuery
+            );
+            // console.timeEnd("Original");
+            console.log("Best Substring:", bestSubstring);
+            // console.time("New");
+            const goodSubstring = this.#findGoodSubstringMatch(
+              bestWindowText,
+              cleanedQuery,
+              2
+            );
+            // console.timeEnd("New");
+            console.log("Good Substring:", goodSubstring);
+            if (!bestSubstring) {
+              return;
+            }
+
+            this.#fuzzyMatchFound = true;
+
+            const [normalizedSubstring] = normalize(bestSubstring);
+            const [normalizedPageContent] = normalize(pageContent);
+
+            const normalizedIndex =
+              normalizedPageContent.indexOf(normalizedSubstring);
+            if (normalizedIndex === -1) {
+              return;
+            }
+
+            const matchedText = [
+              pageContent.slice(
+                normalizedIndex,
+                normalizedIndex + bestSubstring.length
+              ),
+            ];
+
+            this.#calculateRegExpMatch(
+              matchedText.map(matchText => ({
+                query: this.#convertToRegExp(matchText, hasDiacritics),
+                color: "rgba(255, 165, 0, 0.3)",
+              })),
+              entireWord,
+              pageIndex,
+              pageContent
+            );
+
+            setTimeout(() => this.#updatePage(pageIndex), 50);
+            this._linkService.goToPage(pageIndex + 1);
           });
-
-          const fuzzyMatches = fuse.search(cleanedQuery);
-          console.log("fuzzyMatches:" + fuzzyMatches);
-          const bestMatch = fuzzyMatches[0];
-          if (!bestMatch) {
-            return;
-          }
-
-          const bestWindowText = bestMatch.item.text;
-          console.log("query length:", cleanedQuery.length);
-          console.time("Original");
-          const bestSubstring = this.#findBestSubstringMatch(
-            bestWindowText,
-            cleanedQuery
-          );
-          console.timeEnd("Original");
-          console.log("Best Substring:", bestSubstring);
-          console.time("New");
-          const goodSubstring = this.#findGoodSubstringMatch(
-            bestWindowText,
-            cleanedQuery,
-            2
-          );
-          console.timeEnd("New");
-          console.log(
-            "Good Substring:",
-            goodSubstring,
-            "(token set similarity)"
-          );
-          if (!bestSubstring) {
-            return;
-          }
-
-          this.#fuzzyMatchFound = true;
-
-          const [normalizedSubstring] = normalize(bestSubstring);
-          const [normalizedPageContent] = normalize(pageContent);
-
-          const normalizedIndex =
-            normalizedPageContent.indexOf(normalizedSubstring);
-          if (normalizedIndex === -1) {
-            return;
-          }
-
-          const matchedText = [
-            pageContent.slice(
-              normalizedIndex,
-              normalizedIndex + bestSubstring.length
-            ),
-          ];
-
-          this.#calculateRegExpMatch(
-            matchedText.map(matchText => ({
-              query: this.#convertToRegExp(matchText, hasDiacritics),
-              color: "rgba(255, 165, 0, 0.3)",
-            })),
-            entireWord,
-            pageIndex,
-            pageContent
-          );
-
-          setTimeout(() => this.#updatePage(pageIndex), 50);
-          this._linkService.goToPage(pageIndex + 1);
-        });
+      }
+      console.log("\n\n\n\n\n");
     }
 
     // When `highlightAll` is set, ensure that the matches on previously
@@ -1076,7 +1084,6 @@ class PDFFindController {
       for (let j = i + 3; j <= textWords.length && j - i <= 40; j++) {
         const phrase = textWords.slice(i, j).join(" ");
         const [normalizedPhrase] = normalize(phrase);
-        // console.log("Phrase:", phrase);
 
         const score =
           normalizedQuery.length < 300
@@ -1084,16 +1091,16 @@ class PDFFindController {
             : this.#tokenSetSimilarity(normalizedPhrase, normalizedQuery);
 
         // Remove these later!!
-        // const similarityScore = this.#similarityScore(
-        //   normalizedPhrase,
-        //   normalizedQuery
-        // );
-        // const tokenSetSimilarity = this.#tokenSetSimilarity(
-        //   normalizedPhrase,
-        //   normalizedQuery
-        // );
-        // console.log(" Levenshtein score:", similarityScore);
-        // console.log("Jaccard similarity:", tokenSetSimilarity, "\n");
+        const similarityScore = this.#similarityScore(
+          normalizedPhrase,
+          normalizedQuery
+        );
+        const tokenSetSimilarity = this.#tokenSetSimilarity(
+          normalizedPhrase,
+          normalizedQuery
+        );
+        console.log(" Levenshtein score:", similarityScore);
+        console.log("Jaccard similarity:", tokenSetSimilarity, "\n");
 
         if (score > highestScore) {
           highestScore = score;
@@ -1126,14 +1133,10 @@ class PDFFindController {
         const phrase = textWords.slice(i, j).join(" ");
         const [normalizedPhrase] = normalize(phrase);
 
-        // const score =
-        //   normalizedQuery.length < 300
-        //     ? this.#similarityScore(normalizedPhrase, normalizedQuery)
-        //     : this.#tokenSetSimilarity(normalizedPhrase, normalizedQuery);
-        const score = this.#tokenSetSimilarity(
-          normalizedPhrase,
-          normalizedQuery
-        );
+        const score =
+          normalizedQuery.length < 300
+            ? this.#similarityScore(normalizedPhrase, normalizedQuery)
+            : this.#tokenSetSimilarity(normalizedPhrase, normalizedQuery);
 
         if (score > highestScore) {
           highestScore = score;

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -416,10 +416,6 @@ class PDFFindController {
 
   #fuzzyMatchFound = false;
 
-  #bestMatchScore = 0;
-
-  #bestMatchText = null;
-
   /**
    * @param {PDFFindControllerOptions} options
    */
@@ -981,72 +977,38 @@ class PDFFindController {
             return;
           }
 
-          // this.#fuzzyMatchFound = true;
-          if (bestSubstring.score > this.#bestMatchScore) {
-            console.log("New best match found with score", bestSubstring.score);
-            console.log(bestSubstring);
-            this.#bestMatchScore = bestSubstring.score;
-            this.#bestMatchText = bestSubstring.text;
+          this.#fuzzyMatchFound = true;
+
+          const [normalizedSubstring] = normalize(bestSubstring);
+          const [normalizedPageContent] = normalize(pageContent);
+
+          const normalizedIndex =
+            normalizedPageContent.indexOf(normalizedSubstring);
+          if (normalizedIndex === -1) {
+            return;
           }
 
-          // const [normalizedSubstring] = normalize(bestSubstring);
-          // const [normalizedPageContent] = normalize(pageContent);
-          //
-          // const normalizedIndex =
-          //   normalizedPageContent.indexOf(normalizedSubstring);
-          // if (normalizedIndex === -1) {
-          //   return;
-          // }
-          //
-          // const matchedText = [
-          //   pageContent.slice(
-          //     normalizedIndex,
-          //     normalizedIndex + bestSubstring.length
-          //   ),
-          // ];
-          //
-          // this.#calculateRegExpMatch(
-          //   matchedText.map(matchText => ({
-          //     query: this.#convertToRegExp(matchText, hasDiacritics),
-          //     color: "rgba(255, 165, 0, 0.3)",
-          //   })),
-          //   entireWord,
-          //   pageIndex,
-          //   pageContent
-          // );
-          //
-          // setTimeout(() => this.#updatePage(pageIndex), 50);
-          // this._linkService.goToPage(pageIndex + 1);
+          const matchedText = [
+            pageContent.slice(
+              normalizedIndex,
+              normalizedIndex + bestSubstring.length
+            ),
+          ];
+
+          this.#calculateRegExpMatch(
+            matchedText.map(matchText => ({
+              query: this.#convertToRegExp(matchText, hasDiacritics),
+              color: "rgba(255, 165, 0, 0.3)",
+            })),
+            entireWord,
+            pageIndex,
+            pageContent
+          );
+
+          setTimeout(() => this.#updatePage(pageIndex), 50);
+          this._linkService.goToPage(pageIndex + 1);
         });
     }
-
-    const [normalizedSubstring] = normalize(this.#bestMatchText);
-    const [normalizedPageContent] = normalize(pageContent);
-
-    const normalizedIndex = normalizedPageContent.indexOf(normalizedSubstring);
-    if (normalizedIndex === -1) {
-      return;
-    }
-
-    const matchedText = [
-      pageContent.slice(
-        normalizedIndex,
-        normalizedIndex + this.#bestMatchText.length
-      ),
-    ];
-
-    this.#calculateRegExpMatch(
-      matchedText.map(matchText => ({
-        query: this.#convertToRegExp(matchText, hasDiacritics),
-        color: "rgba(255, 165, 0, 0.3)",
-      })),
-      entireWord,
-      pageIndex,
-      pageContent
-    );
-
-    setTimeout(() => this.#updatePage(pageIndex), 50);
-    this._linkService.goToPage(pageIndex + 1);
 
     // When `highlightAll` is set, ensure that the matches on previously
     // rendered (and still active) pages are correctly highlighted.
@@ -1128,7 +1090,7 @@ class PDFFindController {
         }
       }
     }
-    return highestScore > 0.3 ? { text: bestMatch, score: highestScore } : null;
+    return highestScore > 0.3 ? bestMatch : null;
   }
 
   #similarityScore(a, b) {

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -968,7 +968,7 @@ class PDFFindController {
           }
 
           const bestWindowText = bestMatch.item.text;
-          const bestSubstring = this.#findBestSubstringMatch(
+          const bestSubstring = this.#findGoodSubstringMatch(
             bestWindowText,
             cleanedQuery
           );
@@ -1095,7 +1095,7 @@ class PDFFindController {
     return fuzzyMatches.sort((a, b) => b.score - a.score);
   }
 
-  #findBestSubstringMatch(text, query) {
+  #findGoodSubstringMatch(text, query) {
     if (!text || !query) {
       return null;
     }

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -913,133 +913,131 @@ class PDFFindController {
       this._pageMatches[pageIndex]?.length > 0 ||
       this.pageHighlights[pageIndex]?.length > 0;
 
-    for (let threshold = 0.9; threshold >= 0.3; threshold -= 0.2) {
-      if (
-        !this.#fuzzyMatchFound &&
-        !hasMatches &&
-        fuzzySearchEnabled &&
-        query.length > 1
-      ) {
-        this._pdfDocument
-          .getPage(pageIndex + 1)
-          .then(pdfPage =>
-            pdfPage.getTextContent({ disableNormalization: true })
-          )
-          .then(textContent => {
-            const originalTextItems = textContent.items
-              .map(item => item.str)
-              .filter(originalTextItem => originalTextItem !== "");
-            const items = [];
+    if (
+      !this.#fuzzyMatchFound &&
+      !hasMatches &&
+      fuzzySearchEnabled &&
+      query.length > 1
+    ) {
+      this._pdfDocument
+        .getPage(pageIndex + 1)
+        .then(pdfPage => pdfPage.getTextContent({ disableNormalization: true }))
+        .then(textContent => {
+          const originalTextItems = textContent.items
+            .map(item => item.str)
+            .filter(originalTextItem => originalTextItem !== "");
+          const items = [];
 
-            originalTextItems.forEach((item, index) => {
-              if (
-                item.length === 1 ||
-                originalTextItems[index - 1]?.length === 1
-              ) {
-                if (items.length > 0) {
-                  items[items.length - 1] = `${items.at(-1)}${item}`;
-                } else {
-                  items.push(item);
-                }
+          originalTextItems.forEach((item, index) => {
+            if (
+              item.length === 1 ||
+              originalTextItems[index - 1]?.length === 1
+            ) {
+              if (items.length > 0) {
+                items[items.length - 1] = `${items.at(-1)}${item}`;
               } else {
                 items.push(item);
               }
-            });
-
-            console.log("items:", items);
-
-            const cleanedQuery = query.replaceAll(/\.{3,}/g, "").trim();
-
-            const windowSize = 5;
-            const step = 1;
-            const slidingChunks = [];
-
-            for (let i = 0; i <= items.length - windowSize; i += step) {
-              const windowChunks = items.slice(i, i + windowSize);
-              slidingChunks.push({
-                text: windowChunks.join("\n"),
-                indices: [i, i + windowSize - 1],
-                items: windowChunks,
-              });
+            } else {
+              items.push(item);
             }
-
-            const fuse = new Fuse(slidingChunks, {
-              keys: ["text"],
-              includeScore: true,
-              threshold,
-              ignoreLocation: true,
-              distance: 100,
-              minMatchCharLength: 3,
-              shouldSort: true,
-            });
-
-            const fuzzyMatches = fuse.search(cleanedQuery);
-            console.log(
-              fuzzyMatches.length,
-              "matches found at threshold:",
-              threshold
-            );
-
-            console.log("best match:", fuzzyMatches[0]);
-            const bestMatch = fuzzyMatches[0];
-            if (!bestMatch) {
-              return;
-            }
-
-            const bestWindowText = bestMatch.item.text;
-            console.log("bestWindowText:", bestWindowText);
-            // console.time("Original");
-            const bestSubstring = this.#findBestSubstringMatch(
-              bestWindowText,
-              cleanedQuery
-            );
-            // console.timeEnd("Original");
-            console.log("Best Substring:", bestSubstring);
-            // console.time("New");
-            const goodSubstring = this.#findGoodSubstringMatch(
-              bestWindowText,
-              cleanedQuery,
-              2
-            );
-            // console.timeEnd("New");
-            console.log("Good Substring:", goodSubstring);
-            if (!bestSubstring) {
-              return;
-            }
-
-            this.#fuzzyMatchFound = true;
-
-            const [normalizedSubstring] = normalize(bestSubstring);
-            const [normalizedPageContent] = normalize(pageContent);
-
-            const normalizedIndex =
-              normalizedPageContent.indexOf(normalizedSubstring);
-            if (normalizedIndex === -1) {
-              return;
-            }
-
-            const matchedText = [
-              pageContent.slice(
-                normalizedIndex,
-                normalizedIndex + bestSubstring.length
-              ),
-            ];
-
-            this.#calculateRegExpMatch(
-              matchedText.map(matchText => ({
-                query: this.#convertToRegExp(matchText, hasDiacritics),
-                color: "rgba(255, 165, 0, 0.3)",
-              })),
-              entireWord,
-              pageIndex,
-              pageContent
-            );
-
-            setTimeout(() => this.#updatePage(pageIndex), 50);
-            this._linkService.goToPage(pageIndex + 1);
           });
-      }
-      console.log("\n\n\n\n\n");
+
+          console.log("items:", items);
+
+          const cleanedQuery = query.replaceAll(/\.{3,}/g, "").trim();
+
+          const windowSize = 5;
+          const step = 1;
+          const slidingChunks = [];
+
+          for (let i = 0; i <= items.length - windowSize; i += step) {
+            const windowChunks = items.slice(i, i + windowSize);
+            slidingChunks.push({
+              text: windowChunks.join("\n"),
+              indices: [i, i + windowSize - 1],
+              items: windowChunks,
+            });
+          }
+
+          console.time("fuse");
+          const fuse = new Fuse(slidingChunks, {
+            keys: ["text"],
+            includeScore: true,
+            threshold: 0.3,
+            ignoreLocation: true,
+            distance: 100,
+            minMatchCharLength: 3,
+            shouldSort: true,
+          });
+          const fuzzyMatches = fuse.search(cleanedQuery);
+          console.timeEnd("fuse");
+          console.log(fuzzyMatches.length, "fuse matches found");
+
+          console.time("tss");
+          const tssMatches = this.#findSubstringMatches(slidingChunks);
+          console.timeEnd("tss");
+          console.log(tssMatches.length, "tss matches found");
+
+          console.log("fuse match:", fuzzyMatches[0].item.text);
+          console.log(" tss match:", tssMatches[0].text);
+          const bestMatch = fuzzyMatches[0];
+          if (!bestMatch) {
+            return;
+          }
+
+          const bestWindowText = bestMatch.item.text;
+          console.log("bestWindowText:", bestWindowText);
+          // console.time("Original");
+          const bestSubstring = this.#findBestSubstringMatch(
+            bestWindowText,
+            cleanedQuery
+          );
+          // console.timeEnd("Original");
+          console.log("Best Substring:", bestSubstring);
+          // console.time("New");
+          const goodSubstring = this.#findGoodSubstringMatch(
+            bestWindowText,
+            cleanedQuery,
+            2
+          );
+          // console.timeEnd("New");
+          console.log("Good Substring:", goodSubstring);
+          if (!bestSubstring) {
+            return;
+          }
+
+          this.#fuzzyMatchFound = true;
+
+          const [normalizedSubstring] = normalize(bestSubstring);
+          const [normalizedPageContent] = normalize(pageContent);
+
+          const normalizedIndex =
+            normalizedPageContent.indexOf(normalizedSubstring);
+          if (normalizedIndex === -1) {
+            return;
+          }
+
+          const matchedText = [
+            pageContent.slice(
+              normalizedIndex,
+              normalizedIndex + bestSubstring.length
+            ),
+          ];
+
+          this.#calculateRegExpMatch(
+            matchedText.map(matchText => ({
+              query: this.#convertToRegExp(matchText, hasDiacritics),
+              color: "rgba(255, 165, 0, 0.3)",
+            })),
+            entireWord,
+            pageIndex,
+            pageContent
+          );
+
+          setTimeout(() => this.#updatePage(pageIndex), 50);
+          this._linkService.goToPage(pageIndex + 1);
+        });
     }
 
     // When `highlightAll` is set, ensure that the matches on previously
@@ -1090,17 +1088,17 @@ class PDFFindController {
             ? this.#similarityScore(normalizedPhrase, normalizedQuery)
             : this.#tokenSetSimilarity(normalizedPhrase, normalizedQuery);
 
-        // Remove these later!!
-        const similarityScore = this.#similarityScore(
-          normalizedPhrase,
-          normalizedQuery
-        );
-        const tokenSetSimilarity = this.#tokenSetSimilarity(
-          normalizedPhrase,
-          normalizedQuery
-        );
-        console.log(" Levenshtein score:", similarityScore);
-        console.log("Jaccard similarity:", tokenSetSimilarity, "\n");
+        // // Remove these later!!
+        // const similarityScore = this.#similarityScore(
+        //   normalizedPhrase,
+        //   normalizedQuery
+        // );
+        // const tokenSetSimilarity = this.#tokenSetSimilarity(
+        //   normalizedPhrase,
+        //   normalizedQuery
+        // );
+        // console.log(" Levenshtein score:", similarityScore);
+        // console.log("Jaccard similarity:", tokenSetSimilarity, "\n");
 
         if (score > highestScore) {
           highestScore = score;
@@ -1146,6 +1144,33 @@ class PDFFindController {
     }
 
     return highestScore > 0.3 ? bestMatch : null;
+  }
+
+  #findSubstringMatches(slidingChunks, query, precision) {
+    const fuzzyMatches = [];
+    const [normalizedQuery] = normalize(query);
+
+    const textWords = slidingChunks.text.split(/\s+/);
+
+    for (let i = 0; i < textWords.length; i += precision) {
+      for (let j = i + 3; j < textWords.length && j - i <= 40; j += precision) {
+        const phrase = textWords.slice(i, j).join(" ");
+        const [normalizedPhrase] = normalize(phrase);
+
+        const score = this.#tokenSetSimilarity(
+          normalizedPhrase,
+          normalizedQuery
+        );
+
+        if (score > 0.3) {
+          fuzzyMatches.push({
+            text: phrase,
+            score,
+          });
+        }
+      }
+    }
+    return fuzzyMatches.sort((a, b) => b.score - a.score);
   }
 
   #similarityScore(a, b) {

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -943,7 +943,7 @@ class PDFFindController {
             }
           });
 
-          console.log("items:", items);
+          // console.log("items:", items);
 
           const cleanedQuery = query.replaceAll(/\.{3,}/g, "").trim();
 
@@ -960,26 +960,26 @@ class PDFFindController {
             });
           }
 
-          console.time("fuse");
-          const fuse = new Fuse(slidingChunks, {
-            keys: ["text"],
-            includeScore: true,
-            threshold: 0.3,
-            ignoreLocation: true,
-            distance: 100,
-            minMatchCharLength: 3,
-            shouldSort: true,
-          });
-          const fuzzyMatches = fuse.search(cleanedQuery);
-          console.timeEnd("fuse");
-          console.log(fuzzyMatches.length, "fuse matches found");
+          // console.time("fuse");
+          // const fuse = new Fuse(slidingChunks, {
+          //   keys: ["text"],
+          //   includeScore: true,
+          //   threshold: 0.3,
+          //   ignoreLocation: true,
+          //   distance: 100,
+          //   minMatchCharLength: 3,
+          //   shouldSort: true,
+          // });
+          // const fuzzyMatches = fuse.search(cleanedQuery);
+          // console.timeEnd("fuse");
+          // console.log(fuzzyMatches.length, "fuse matches found");
 
-          console.time("tss");
+          // console.time("tss");
           const tssMatches = this.#findSubstringMatches(
             slidingChunks,
             cleanedQuery
           );
-          console.timeEnd("tss");
+          // console.timeEnd("tss");
           console.log(tssMatches.length, "tss matches found");
 
           const bestMatch = tssMatches[0];
@@ -1156,7 +1156,7 @@ class PDFFindController {
 
       const score = this.#tokenSetSimilarity(normalizedPhrase, normalizedQuery);
 
-      if (score > 0.3) {
+      if (score > 0.25) {
         fuzzyMatches.push({
           item: slidingChunks[i],
           refIndex: i,

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -416,6 +416,10 @@ class PDFFindController {
 
   #fuzzyMatchFound = false;
 
+  #bestMatchScore = 0;
+
+  #bestMatchText = null;
+
   /**
    * @param {PDFFindControllerOptions} options
    */
@@ -977,38 +981,72 @@ class PDFFindController {
             return;
           }
 
-          this.#fuzzyMatchFound = true;
-
-          const [normalizedSubstring] = normalize(bestSubstring);
-          const [normalizedPageContent] = normalize(pageContent);
-
-          const normalizedIndex =
-            normalizedPageContent.indexOf(normalizedSubstring);
-          if (normalizedIndex === -1) {
-            return;
+          // this.#fuzzyMatchFound = true;
+          if (bestSubstring.score > this.#bestMatchScore) {
+            console.log("New best match found with score", bestSubstring.score);
+            console.log(bestSubstring);
+            this.#bestMatchScore = bestSubstring.score;
+            this.#bestMatchText = bestSubstring.text;
           }
 
-          const matchedText = [
-            pageContent.slice(
-              normalizedIndex,
-              normalizedIndex + bestSubstring.length
-            ),
-          ];
-
-          this.#calculateRegExpMatch(
-            matchedText.map(matchText => ({
-              query: this.#convertToRegExp(matchText, hasDiacritics),
-              color: "rgba(255, 165, 0, 0.3)",
-            })),
-            entireWord,
-            pageIndex,
-            pageContent
-          );
-
-          setTimeout(() => this.#updatePage(pageIndex), 50);
-          this._linkService.goToPage(pageIndex + 1);
+          // const [normalizedSubstring] = normalize(bestSubstring);
+          // const [normalizedPageContent] = normalize(pageContent);
+          //
+          // const normalizedIndex =
+          //   normalizedPageContent.indexOf(normalizedSubstring);
+          // if (normalizedIndex === -1) {
+          //   return;
+          // }
+          //
+          // const matchedText = [
+          //   pageContent.slice(
+          //     normalizedIndex,
+          //     normalizedIndex + bestSubstring.length
+          //   ),
+          // ];
+          //
+          // this.#calculateRegExpMatch(
+          //   matchedText.map(matchText => ({
+          //     query: this.#convertToRegExp(matchText, hasDiacritics),
+          //     color: "rgba(255, 165, 0, 0.3)",
+          //   })),
+          //   entireWord,
+          //   pageIndex,
+          //   pageContent
+          // );
+          //
+          // setTimeout(() => this.#updatePage(pageIndex), 50);
+          // this._linkService.goToPage(pageIndex + 1);
         });
     }
+
+    const [normalizedSubstring] = normalize(this.#bestMatchText);
+    const [normalizedPageContent] = normalize(pageContent);
+
+    const normalizedIndex = normalizedPageContent.indexOf(normalizedSubstring);
+    if (normalizedIndex === -1) {
+      return;
+    }
+
+    const matchedText = [
+      pageContent.slice(
+        normalizedIndex,
+        normalizedIndex + this.#bestMatchText.length
+      ),
+    ];
+
+    this.#calculateRegExpMatch(
+      matchedText.map(matchText => ({
+        query: this.#convertToRegExp(matchText, hasDiacritics),
+        color: "rgba(255, 165, 0, 0.3)",
+      })),
+      entireWord,
+      pageIndex,
+      pageContent
+    );
+
+    setTimeout(() => this.#updatePage(pageIndex), 50);
+    this._linkService.goToPage(pageIndex + 1);
 
     // When `highlightAll` is set, ensure that the matches on previously
     // rendered (and still active) pages are correctly highlighted.
@@ -1090,7 +1128,7 @@ class PDFFindController {
         }
       }
     }
-    return highestScore > 0.3 ? bestMatch : null;
+    return highestScore > 0.3 ? { text: bestMatch, score: highestScore } : null;
   }
 
   #similarityScore(a, b) {

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -874,6 +874,7 @@ class PDFFindController {
 
   #calculateMatch(pageIndex) {
     const query = this.#query;
+    console.log("Query: ", query, "\n");
     const termHighlighting = this.termHighlighting;
     if (query.length === 0 && Object.keys(termHighlighting).length === 0) {
       return; // Do nothing: the matches should be wiped out already.
@@ -944,6 +945,7 @@ class PDFFindController {
           });
 
           const cleanedQuery = query.replaceAll(/\.{3,}/g, "").trim();
+          console.log("Cleaned query: ", cleanedQuery, "\n");
 
           const windowSize = 5;
           const step = 1;
@@ -967,6 +969,8 @@ class PDFFindController {
             minMatchCharLength: 3,
           });
 
+          console.log("Sliding chunks:", slidingChunks, "\n");
+
           const fuzzyMatches = fuse.search(cleanedQuery);
           const bestMatch = fuzzyMatches[0];
           if (!bestMatch) {
@@ -981,6 +985,8 @@ class PDFFindController {
           if (!bestSubstring) {
             return;
           }
+
+          console.log("Best substring: ", bestSubstring, "\n");
 
           this.#fuzzyMatchFound = true;
 
@@ -1045,6 +1051,9 @@ class PDFFindController {
     if (!text || !query) {
       return null;
     }
+    console.log("Finding best substring match between:");
+    console.log("Text:", text);
+    console.log("Query:", query, "\n");
 
     const textWords = text.split(/\s+/);
 
@@ -1057,11 +1066,24 @@ class PDFFindController {
       for (let j = i + 3; j <= textWords.length && j - i <= 40; j++) {
         const phrase = textWords.slice(i, j).join(" ");
         const [normalizedPhrase] = normalize(phrase);
+        console.log("Phrase:", phrase);
 
         const score =
           normalizedQuery.length < 300
             ? this.#similarityScore(normalizedPhrase, normalizedQuery)
             : this.#tokenSetSimilarity(normalizedPhrase, normalizedQuery);
+
+        // Remove these later!!
+        const similarityScore = this.#similarityScore(
+          normalizedPhrase,
+          normalizedQuery
+        );
+        const tokenSetSimilarity = this.#tokenSetSimilarity(
+          normalizedPhrase,
+          normalizedQuery
+        );
+        console.log(" Levenshtein score:", similarityScore);
+        console.log("Jaccard similarity:", tokenSetSimilarity, "\n");
 
         if (score > highestScore) {
           highestScore = score;

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -982,30 +982,28 @@ class PDFFindController {
           console.timeEnd("tss");
           console.log(tssMatches.length, "tss matches found");
 
-          console.log("fuse match:", fuzzyMatches[0].item.text);
-          console.log(" tss match:", tssMatches[0].item.text);
-          const bestMatch = fuzzyMatches[0];
+          const bestMatch = tssMatches[0];
           if (!bestMatch) {
             return;
           }
 
           const bestWindowText = bestMatch.item.text;
-          console.log("bestWindowText:", bestWindowText);
+
           // console.time("Original");
-          const bestSubstring = this.#findBestSubstringMatch(
-            bestWindowText,
-            cleanedQuery
-          );
+          // const bestSubstring = this.#findBestSubstringMatch(
+          //   bestWindowText,
+          //   cleanedQuery
+          // );
           // console.timeEnd("Original");
-          console.log("Best Substring:", bestSubstring);
+          // console.log("Best Substring:", bestSubstring);
           // console.time("New");
-          const goodSubstring = this.#findGoodSubstringMatch(
+          const bestSubstring = this.#findGoodSubstringMatch(
             bestWindowText,
             cleanedQuery,
             2
           );
           // console.timeEnd("New");
-          console.log("Good Substring:", goodSubstring);
+          // console.log("Good Substring:", goodSubstring);
           if (!bestSubstring) {
             return;
           }
@@ -1069,49 +1067,49 @@ class PDFFindController {
     }
   }
 
-  #findBestSubstringMatch(text, query) {
-    if (!text || !query) {
-      return null;
-    }
-
-    const textWords = text.split(/\s+/);
-
-    let bestMatch = null;
-    let highestScore = 0;
-
-    const [normalizedQuery] = normalize(query);
-
-    for (let i = 0; i < textWords.length; i++) {
-      for (let j = i + 3; j <= textWords.length && j - i <= 40; j++) {
-        const phrase = textWords.slice(i, j).join(" ");
-        const [normalizedPhrase] = normalize(phrase);
-
-        const score =
-          normalizedQuery.length < 300
-            ? this.#similarityScore(normalizedPhrase, normalizedQuery)
-            : this.#tokenSetSimilarity(normalizedPhrase, normalizedQuery);
-
-        // // Remove these later!!
-        // const similarityScore = this.#similarityScore(
-        //   normalizedPhrase,
-        //   normalizedQuery
-        // );
-        // const tokenSetSimilarity = this.#tokenSetSimilarity(
-        //   normalizedPhrase,
-        //   normalizedQuery
-        // );
-        // console.log(" Levenshtein score:", similarityScore);
-        // console.log("Jaccard similarity:", tokenSetSimilarity, "\n");
-
-        if (score > highestScore) {
-          highestScore = score;
-          bestMatch = phrase;
-        }
-      }
-    }
-
-    return highestScore > 0.3 ? bestMatch : null;
-  }
+  // #findBestSubstringMatch(text, query) {
+  //   if (!text || !query) {
+  //     return null;
+  //   }
+  //
+  //   const textWords = text.split(/\s+/);
+  //
+  //   let bestMatch = null;
+  //   let highestScore = 0;
+  //
+  //   const [normalizedQuery] = normalize(query);
+  //
+  //   for (let i = 0; i < textWords.length; i++) {
+  //     for (let j = i + 3; j <= textWords.length && j - i <= 40; j++) {
+  //       const phrase = textWords.slice(i, j).join(" ");
+  //       const [normalizedPhrase] = normalize(phrase);
+  //
+  //       const score =
+  //         normalizedQuery.length < 300
+  //           ? this.#similarityScore(normalizedPhrase, normalizedQuery)
+  //           : this.#tokenSetSimilarity(normalizedPhrase, normalizedQuery);
+  //
+  //       // // Remove these later!!
+  //       // const similarityScore = this.#similarityScore(
+  //       //   normalizedPhrase,
+  //       //   normalizedQuery
+  //       // );
+  //       // const tokenSetSimilarity = this.#tokenSetSimilarity(
+  //       //   normalizedPhrase,
+  //       //   normalizedQuery
+  //       // );
+  //       // console.log(" Levenshtein score:", similarityScore);
+  //       // console.log("Jaccard similarity:", tokenSetSimilarity, "\n");
+  //
+  //       if (score > highestScore) {
+  //         highestScore = score;
+  //         bestMatch = phrase;
+  //       }
+  //     }
+  //   }
+  //
+  //   return highestScore > 0.3 ? bestMatch : null;
+  // }
 
   #findGoodSubstringMatch(text, query, precision) {
     if (!text || !query) {

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -957,13 +957,13 @@ class PDFFindController {
             });
           }
 
-          const tssMatches = this.#findSubstringMatches(
+          const fuzzyMatches = this.#findSubstringMatches(
             slidingChunks,
             cleanedQuery,
             0.2
           );
 
-          const bestMatch = tssMatches[0];
+          const bestMatch = fuzzyMatches[0];
           if (!bestMatch) {
             return;
           }
@@ -1072,8 +1072,8 @@ class PDFFindController {
 
     for (let i = 0; i < textWords.length; i += coarseness) {
       for (
-        let j = Math.floor(i + queryLength * 0.5);
-        j <= textWords.length && j - i <= queryLength * 2;
+        let j = Math.floor(i + queryLength * 0.75);
+        j <= textWords.length && j - i <= Math.ceil(queryLength * 1.5);
         j += coarseness
       ) {
         const phrase = textWords.slice(i, j).join(" ");


### PR DESCRIPTION
Summary of changes:
- Stop using FuseJS (which implements costly Levenshtein distance) and instead use token set similarity as a first, rough filter
- Try substrings of length between 75% of the query length and 150% of the query length (previously using hard-coded 3-40 words)
  - Ex: If query length is 20, we will try substring lengths between 15 and 30
- Introduce `coarseness` as one tenth of query length to check fewer substrings. Only check substrings of lengths that are multiples of `coarseness` and start at indices that are multiples of `coarseness`
  - Ex: If query length is 20, we will try substrings of length 15, 17, 19, …, 29 starting from indices 0, 2, 4, 6, …
