### PR TITLE
Re-highlight after switching between tabs

### DIFF
--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -1027,11 +1027,12 @@ class PDFFindController {
     );
 
     this._matchesCountTotal += pageMatchesCount;
-    if (this.#updateMatchesCountOnProgress) {
-      this.#updateUIResultsCount();
-    } else if (++this.#visitedPagesCount === this._linkService.pagesCount) {
+    if (++this.#visitedPagesCount === this._linkService.pagesCount) {
+      this.#fuzzyMatchFound = false;
       // For example, in GeckoView we want to have only the final update because
       // the Java side provides only one object to update the counts.
+      this.#updateUIResultsCount();
+    } else if (this.#updateMatchesCountOnProgress) {
       this.#updateUIResultsCount();
     }
   }
@@ -1460,8 +1461,6 @@ class PDFFindController {
   }
 
   #updateUIResultsCount() {
-    console.log("Setting fuzzy match found to false");
-    this.#fuzzyMatchFound = false;
     this._eventBus.dispatch("updatefindmatchescount", {
       source: this,
       matchesCount: this.#requestMatchesCount(),

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -1460,6 +1460,8 @@ class PDFFindController {
   }
 
   #updateUIResultsCount() {
+    console.log("Setting fuzzy match found to false");
+    this.#fuzzyMatchFound = false;
     this._eventBus.dispatch("updatefindmatchescount", {
       source: this,
       matchesCount: this.#requestMatchesCount(),

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -504,6 +504,7 @@ class PDFFindController {
     }
     this.#state = state;
     this.#state.fuzzySearchEnabled = state.fuzzySearchEnabled ?? false;
+    this.#fuzzyMatchFound = false;
     if (type !== "highlightallchange") {
       this.#updateUIState(FindState.PENDING);
     }
@@ -1203,7 +1204,6 @@ class PDFFindController {
 
     const { fuzzySearchEnabled } = this.#state;
     if (fuzzySearchEnabled && index === this._linkService.pagesCount - 1) {
-      this.#fuzzyMatchFound = false;
       this._eventBus.dispatch("fuzzysearching", {
         source: this,
         isSearching: false,

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -1027,12 +1027,11 @@ class PDFFindController {
     );
 
     this._matchesCountTotal += pageMatchesCount;
-    if (++this.#visitedPagesCount === this._linkService.pagesCount) {
-      this.#fuzzyMatchFound = false;
+    if (this.#updateMatchesCountOnProgress) {
+      this.#updateUIResultsCount();
+    } else if (++this.#visitedPagesCount === this._linkService.pagesCount) {
       // For example, in GeckoView we want to have only the final update because
       // the Java side provides only one object to update the counts.
-      this.#updateUIResultsCount();
-    } else if (this.#updateMatchesCountOnProgress) {
       this.#updateUIResultsCount();
     }
   }
@@ -1204,6 +1203,7 @@ class PDFFindController {
 
     const { fuzzySearchEnabled } = this.#state;
     if (fuzzySearchEnabled && index === this._linkService.pagesCount - 1) {
+      this.#fuzzyMatchFound = false;
       this._eventBus.dispatch("fuzzysearching", {
         source: this,
         isSearching: false,


### PR DESCRIPTION
This change addresses an issue where navigating between pages such as citation highlighting and sentiment highlighting would not highlight fuzzy matches except for the first time.