### PR TITLE
RC-23088

### DIFF
--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -709,7 +709,8 @@ class PDFFindController {
    * Determine which queries can be matched in the document
    * Return a set of indices that can be found
    */
-  #onGetHighlightableQueries() {
+  #onGetHighlightableQueries(state) {
+    this.#state = state;
     const query = this.#query;
     if (query.length === 0) {
       return; // Do nothing: no queries to match.

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -711,12 +711,17 @@ class PDFFindController {
    */
   #onGetHighlightableQueries(state) {
     this.#state = state;
-    this.#extractText();
 
     const termHighlighting = this.termHighlighting;
     if (Object.keys(termHighlighting).length === 0) {
       return; // Do nothing: no queries to match.
     }
+
+    this._extractTextPromises = [];
+    this._pageContents = [];
+    this._pageDiffs = [];
+    this._hasDiacritics = [];
+    this.#extractText();
 
     const hasDiacritics = this._hasDiacritics[0];
     const termHighlightingQueries = Object.entries(termHighlighting).map(
@@ -746,7 +751,7 @@ class PDFFindController {
 
       queries.forEach((query, index) => {
         const queryString = query.query;
-        if (queryString.exec(pageContent)) {
+        if (queryString.test(pageContent)) {
           foundIndices.add(index);
         }
       });

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -734,28 +734,31 @@ class PDFFindController {
         }
       );
 
-      const foundIndices = this.#getRegExpMatches(termHighlightingQueries);
+      const queryPageMap = this.#getRegExpMatches(termHighlightingQueries);
       this._eventBus.dispatch("returnhighlightablequeryindices", {
         source: this,
-        foundIndices,
+        queryPageMap,
       });
     });
   }
 
   #getRegExpMatches(queries) {
-    const foundIndices = new Set();
+    const queryPageMap = {};
+    queries.forEach((_, index) => {
+      queryPageMap[index] = null;
+    });
 
     for (let i = 0; i < this._linkService.pagesCount; i++) {
       const pageContent = this._pageContents[i];
 
       queries.forEach((query, index) => {
         const queryString = query.query;
-        if (queryString.test(pageContent)) {
-          foundIndices.add(index);
+        if (queryPageMap[index] === null && queryString.test(pageContent)) {
+          queryPageMap[index] = i;
         }
       });
     }
-    return foundIndices;
+    return queryPageMap;
   }
 
   /**

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -711,6 +711,8 @@ class PDFFindController {
    */
   #onGetHighlightableQueries(state) {
     this.#state = state;
+    this.#extractText();
+
     const termHighlighting = this.termHighlighting;
     if (Object.keys(termHighlighting).length === 0) {
       return; // Do nothing: no queries to match.
@@ -743,7 +745,8 @@ class PDFFindController {
       const pageContent = this._pageContents[i];
 
       queries.forEach((query, index) => {
-        if (query.exec(pageContent)) {
+        const queryString = query.query;
+        if (queryString.exec(pageContent)) {
           foundIndices.add(index);
         }
       });

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -711,20 +711,24 @@ class PDFFindController {
    */
   #onGetHighlightableQueries(state) {
     this.#state = state;
-    const query = this.#query;
-    if (query.length === 0) {
+    const termHighlighting = this.termHighlighting;
+    if (Object.keys(termHighlighting).length === 0) {
       return; // Do nothing: no queries to match.
     }
 
     const hasDiacritics = this._hasDiacritics[0];
-    const queries = [
-      {
-        query: this.#convertToRegExp(query, hasDiacritics),
-        color: null,
-      },
-    ];
+    const termHighlightingQueries = Object.entries(termHighlighting).map(
+      ([term, color]) => {
+        const termQuery = this.#normalizeQuery(term);
 
-    const foundIndices = this.#getRegExpMatches(queries);
+        return {
+          query: this.#convertToRegExp(termQuery, hasDiacritics),
+          color,
+        };
+      }
+    );
+
+    const foundIndices = this.#getRegExpMatches(termHighlightingQueries);
 
     this._eventBus.dispatch("returnhighlightablequeryindices", {
       source: this,

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -707,7 +707,7 @@ class PDFFindController {
 
   /**
    * Determine which queries can be matched in the document
-   * Return a set of indices that can be found
+   * Return a map from the query index to the page that query is found on
    */
   #onGetHighlightableQueries(state) {
     this.#state = state;

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -79,8 +79,6 @@ const DIACRITICS_EXCEPTION = new Set([
 let DIACRITICS_EXCEPTION_STR; // Lazily initialized, see below.
 
 const DIACRITICS_REG_EXP = /\p{M}+/gu;
-const SPECIAL_CHARS_REG_EXP =
-  /([.*+?^${}()|[\]\\])|(\p{P})|(\s+)|(\p{M})|(\p{L})/gu;
 const NOT_DIACRITIC_FROM_END_REG_EXP = /([^\p{M}])\p{M}*$/u;
 const NOT_DIACRITIC_FROM_START_REG_EXP = /^\p{M}*([^\p{M}])/u;
 
@@ -776,6 +774,8 @@ class PDFFindController {
   }
 
   #convertToRegExpString(query, hasDiacritics) {
+    const SPECIAL_CHARS_REG_EXP =
+      /([.*+?^${}()|[\]\\])|(\p{P})|(\s+)|(\p{M})|(\p{L})/gu;
     const { matchDiacritics } = this.#state;
     let isUnicode = false;
     query = query.replaceAll(

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -743,7 +743,7 @@ class PDFFindController {
       const pageContent = this._pageContents[i];
 
       queries.forEach((query, index) => {
-        if (query.test(pageContent)) {
+        if (query.exec(pageContent)) {
           foundIndices.add(index);
         }
       });


### PR DESCRIPTION
Created a new event for sentiment highlighting. This event takes in a list of `termColors` and returns a map from the index of each `termColor` to what page it can be found on in the document. If a term cannot be found, its index is mapped to null. This is intended to be used by sentiment highlighting which needs to know the terms that can and cannot be highlighted.