### PR TITLE
Sentiment highlighting improvements

### DIFF
--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -709,7 +709,8 @@ class PDFFindController {
    * Determine which queries can be matched in the document
    * Return a set of indices that can be found
    */
-  #onGetHighlightableQueries() {
+  #onGetHighlightableQueries(state) {
+    this.#state = state;
     const query = this.#query;
     if (query.length === 0) {
       return; // Do nothing: no queries to match.

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -711,12 +711,17 @@ class PDFFindController {
    */
   #onGetHighlightableQueries(state) {
     this.#state = state;
-    this.#extractText();
 
     const termHighlighting = this.termHighlighting;
     if (Object.keys(termHighlighting).length === 0) {
       return; // Do nothing: no queries to match.
     }
+
+    this._extractTextPromises = [];
+    this._pageContents = [];
+    this._pageDiffs = [];
+    this._hasDiacritics = [];
+    this.#extractText();
 
     const hasDiacritics = this._hasDiacritics[0];
     const termHighlightingQueries = Object.entries(termHighlighting).map(
@@ -746,7 +751,7 @@ class PDFFindController {
 
       queries.forEach((query, index) => {
         const queryString = query.query;
-        if (queryString.exec(pageContent)) {
+        if (queryString.test(pageContent)) {
           foundIndices.add(index);
         }
       });

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -734,28 +734,31 @@ class PDFFindController {
         }
       );
 
-      const foundIndices = this.#getRegExpMatches(termHighlightingQueries);
+      const queryPageMap = this.#getRegExpMatches(termHighlightingQueries);
       this._eventBus.dispatch("returnhighlightablequeryindices", {
         source: this,
-        foundIndices,
+        queryPageMap,
       });
     });
   }
 
   #getRegExpMatches(queries) {
-    const foundIndices = new Set();
+    const queryPageMap = {};
+    queries.forEach((_, index) => {
+      queryPageMap[index] = null;
+    });
 
     for (let i = 0; i < this._linkService.pagesCount; i++) {
       const pageContent = this._pageContents[i];
 
       queries.forEach((query, index) => {
         const queryString = query.query;
-        if (queryString.test(pageContent)) {
-          foundIndices.add(index);
+        if (queryPageMap[index] === null && queryString.test(pageContent)) {
+          queryPageMap[index] = i;
         }
       });
     }
-    return foundIndices;
+    return queryPageMap;
   }
 
   /**

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -711,6 +711,8 @@ class PDFFindController {
    */
   #onGetHighlightableQueries(state) {
     this.#state = state;
+    this.#extractText();
+
     const termHighlighting = this.termHighlighting;
     if (Object.keys(termHighlighting).length === 0) {
       return; // Do nothing: no queries to match.
@@ -743,7 +745,8 @@ class PDFFindController {
       const pageContent = this._pageContents[i];
 
       queries.forEach((query, index) => {
-        if (query.exec(pageContent)) {
+        const queryString = query.query;
+        if (queryString.exec(pageContent)) {
           foundIndices.add(index);
         }
       });

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -711,20 +711,24 @@ class PDFFindController {
    */
   #onGetHighlightableQueries(state) {
     this.#state = state;
-    const query = this.#query;
-    if (query.length === 0) {
+    const termHighlighting = this.termHighlighting;
+    if (Object.keys(termHighlighting).length === 0) {
       return; // Do nothing: no queries to match.
     }
 
     const hasDiacritics = this._hasDiacritics[0];
-    const queries = [
-      {
-        query: this.#convertToRegExp(query, hasDiacritics),
-        color: null,
-      },
-    ];
+    const termHighlightingQueries = Object.entries(termHighlighting).map(
+      ([term, color]) => {
+        const termQuery = this.#normalizeQuery(term);
 
-    const foundIndices = this.#getRegExpMatches(queries);
+        return {
+          query: this.#convertToRegExp(termQuery, hasDiacritics),
+          color,
+        };
+      }
+    );
+
+    const foundIndices = this.#getRegExpMatches(termHighlightingQueries);
 
     this._eventBus.dispatch("returnhighlightablequeryindices", {
       source: this,

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -707,7 +707,7 @@ class PDFFindController {
 
   /**
    * Determine which queries can be matched in the document
-   * Return a set of indices that can be found
+   * Return a map from the query index to the page that query is found on
    */
   #onGetHighlightableQueries(state) {
     this.#state = state;

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -79,8 +79,6 @@ const DIACRITICS_EXCEPTION = new Set([
 let DIACRITICS_EXCEPTION_STR; // Lazily initialized, see below.
 
 const DIACRITICS_REG_EXP = /\p{M}+/gu;
-const SPECIAL_CHARS_REG_EXP =
-  /([.*+?^${}()|[\]\\])|(\p{P})|(\s+)|(\p{M})|(\p{L})/gu;
 const NOT_DIACRITIC_FROM_END_REG_EXP = /([^\p{M}])\p{M}*$/u;
 const NOT_DIACRITIC_FROM_START_REG_EXP = /^\p{M}*([^\p{M}])/u;
 
@@ -776,6 +774,8 @@ class PDFFindController {
   }
 
   #convertToRegExpString(query, hasDiacritics) {
+    const SPECIAL_CHARS_REG_EXP =
+      /([.*+?^${}()|[\]\\])|(\p{P})|(\s+)|(\p{M})|(\p{L})/gu;
     const { matchDiacritics } = this.#state;
     let isUnicode = false;
     query = query.replaceAll(

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -743,7 +743,7 @@ class PDFFindController {
       const pageContent = this._pageContents[i];
 
       queries.forEach((query, index) => {
-        if (query.test(pageContent)) {
+        if (query.exec(pageContent)) {
           foundIndices.add(index);
         }
       });

--- a/web/text_highlighter.js
+++ b/web/text_highlighter.js
@@ -177,7 +177,11 @@ class TextHighlighter {
 
     function styleSpan(span, backgroundColor) {
       span.style.background = backgroundColor; // backgroundColor is converted to rgb or rgba automatically
-      setAlpha(span); // Override alpha value to ensure we have appropriate opacity on highlights
+      if (span.className.includes("selected")) {
+        setAlpha(span, 0.5);
+      } else {
+        setAlpha(span); // Override alpha value to ensure we have appropriate opacity on highlights
+      }
       span.style.margin = "-1px";
       span.style.padding = "1px";
       span.style.borderRadius = "0";
@@ -276,7 +280,7 @@ class TextHighlighter {
           begin.offset,
           end.offset,
           "highlight" + highlightSuffix,
-          isSelected ? null : match.color
+          match.color
         );
       } else {
         selectedLeft = appendTextToDiv(
@@ -284,7 +288,7 @@ class TextHighlighter {
           begin.offset,
           infinity.offset,
           "highlight begin" + highlightSuffix,
-          isSelected ? null : match.color
+          match.color
         );
         for (let n0 = begin.divIdx + 1, n1 = end.divIdx; n0 < n1; n0++) {
           textDivs[n0].className = "highlight middle" + highlightSuffix;
@@ -292,11 +296,7 @@ class TextHighlighter {
             styleSpan(textDivs[n0], match.color);
           }
         }
-        beginText(
-          end,
-          "highlight end" + highlightSuffix,
-          isSelected ? null : match.color
-        );
+        beginText(end, "highlight end" + highlightSuffix, match.color);
       }
       prevEnd = end;
 

--- a/web/text_highlighter.js
+++ b/web/text_highlighter.js
@@ -178,7 +178,7 @@ class TextHighlighter {
     function styleSpan(span, backgroundColor) {
       span.style.background = backgroundColor; // backgroundColor is converted to rgb or rgba automatically
       if (span.className.includes("selected")) {
-        setAlpha(span, 0.5);
+        setAlpha(span, ".6"); // Highlight selected term with original color but more opacity
       } else {
         setAlpha(span); // Override alpha value to ensure we have appropriate opacity on highlights
       }
@@ -192,7 +192,7 @@ class TextHighlighter {
         .split(",")
         .slice(0, 3)
         .map(element => element.replace(")", "").trim());
-      backgroundElements.push(".25)");
+      backgroundElements.push(alpha);
       span.style.background = backgroundElements.join(", ");
     }
 

--- a/web/text_highlighter.js
+++ b/web/text_highlighter.js
@@ -176,9 +176,9 @@ class TextHighlighter {
     }
 
     function styleSpan(span, backgroundColor) {
-      span.style.background = backgroundColor; // backgroundColor is converted to rgb or rgba automatically
+      span.style.background = backgroundColor ?? "rgba(0 166 255 / 0.25)"; // backgroundColor is converted to rgb or rgba automatically
       if (span.className.includes("selected")) {
-        setAlpha(span, ".6"); // Highlight selected term with original color but more opacity
+        setAlpha(span, ".5"); // Highlight selected term with original color but more opacity
       } else {
         setAlpha(span); // Override alpha value to ensure we have appropriate opacity on highlights
       }
@@ -217,7 +217,7 @@ class TextHighlighter {
           span.className = `${className} appended`;
         }
 
-        if (bgColor) {
+        if (bgColor || className.includes("selected")) {
           styleSpan(span, bgColor);
         }
 

--- a/web/text_highlighter.js
+++ b/web/text_highlighter.js
@@ -176,10 +176,8 @@ class TextHighlighter {
     }
 
     function styleSpan(span, backgroundColor) {
-      if (!span.className.includes("selected")) {
-        span.style.background = backgroundColor; // backgroundColor is converted to rgb or rgba automatically
-        setAlpha(span); // Override alpha value to ensure we have appropriate opacity on highlights
-      }
+      span.style.background = backgroundColor; // backgroundColor is converted to rgb or rgba automatically
+      setAlpha(span); // Override alpha value to ensure we have appropriate opacity on highlights
       span.style.margin = "-1px";
       span.style.padding = "1px";
       span.style.borderRadius = "0";

--- a/web/text_layer_builder.css
+++ b/web/text_layer_builder.css
@@ -84,7 +84,8 @@
     }
 
     &.selected {
-      background-color: var(--highlight-selected-bg-color);
+      background-color: color-mix(in srgb, currentColor 50%, transparent);
+      /*background-color: var(--highlight-selected-bg-color);*/
       backdrop-filter: var(--highlight-selected-backdrop-filter);
     }
   }

--- a/web/text_layer_builder.css
+++ b/web/text_layer_builder.css
@@ -84,9 +84,11 @@
     }
 
     &.selected {
-      background-color: color-mix(in srgb, currentColor 50%, transparent);
+      /*background-color: color-mix(in srgb, currentColor 50%, transparent);*/
       /*background-color: var(--highlight-selected-bg-color);*/
+      background-color: background;
       backdrop-filter: var(--highlight-selected-backdrop-filter);
+      box-shadow: 2px 2px darkgrey;
     }
   }
 

--- a/web/text_layer_builder.css
+++ b/web/text_layer_builder.css
@@ -84,8 +84,6 @@
     }
 
     &.selected {
-      /*background-color: color-mix(in srgb, currentColor 50%, transparent);*/
-      /*background-color: var(--highlight-selected-bg-color);*/
       background-color: background;
       backdrop-filter: var(--highlight-selected-backdrop-filter);
       box-shadow: 2px 2px darkgrey;


### PR DESCRIPTION
This is a combination of two tickets.
RC-23088:
- Created a new event for sentiment highlighting. This event takes in a list of termColors and returns a map from the index of each termColor to what page it can be found on in the document. If a term cannot be found, its index is mapped to null. This is intended to be used by sentiment highlighting which needs to know the terms that can and cannot be highlighted.

RC-21855:
- Selected sentiment highlights with the original color (red/green) but with more opacity and a drop-shadow to make it stand out