### PR TITLE
V78 bug fixes

### DIFF
--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -273,7 +273,7 @@ class AnnotationElement {
     // But if an annotation is above an other one, then we must draw it
     // after the other one whatever the order is in the DOM, hence the
     // use of the z-index.
-    style.zIndex = "0"; // Hide all links in the PDF viewer
+    style.zIndex = 5 + this.parent.zIndex++; // Add 5 to ensure we are above the text layer
 
     if (data.popupRef) {
       container.setAttribute("aria-haspopup", "dialog");

--- a/src/display/annotation_layer.js
+++ b/src/display/annotation_layer.js
@@ -273,7 +273,7 @@ class AnnotationElement {
     // But if an annotation is above an other one, then we must draw it
     // after the other one whatever the order is in the DOM, hence the
     // use of the z-index.
-    style.zIndex = 5 + this.parent.zIndex++; // Add 5 to ensure we are above the text layer
+    style.zIndex = "0"; // Hide all links in the PDF viewer
 
     if (data.popupRef) {
       container.setAttribute("aria-haspopup", "dialog");

--- a/web/annotation_layer_builder.js
+++ b/web/annotation_layer_builder.js
@@ -138,8 +138,6 @@ class AnnotationLayerBuilder {
       viewport: viewport.clone({ dontFlip: true }),
     });
 
-    this.#coverSplitLinks(annotations);
-
     await this.annotationLayer.render({
       annotations,
       imageResourcesPath: this.imageResourcesPath,
@@ -182,29 +180,6 @@ class AnnotationLayerBuilder {
       return;
     }
     this.div.hidden = true;
-  }
-
-  // Fixes bug where links were being split into multiple clickable pieces
-  // by increasing the rectangle of one annotation to cover multiple.
-  // For example emails had separate clickable parts for the username and domain
-  #coverSplitLinks(annotations) {
-    for (const [index, annotation] of annotations.entries()) {
-      if (index > 0) {
-        const prev = annotations[index - 1];
-        const prevStart = prev.rect[0];
-        const currentStart = annotation.rect[0];
-        const prevEnd = prev.rect[2];
-        const prevTop = prev.rect[3];
-        const currentTop = annotation.rect[3];
-        if (
-          prev.url === annotation.url &&
-          prevTop === currentTop &&
-          prevEnd === currentStart
-        ) {
-          annotation.rect[0] = prevStart;
-        }
-      }
-    }
   }
 
   #updatePresentationModeState(state) {

--- a/web/annotation_layer_builder.js
+++ b/web/annotation_layer_builder.js
@@ -138,6 +138,8 @@ class AnnotationLayerBuilder {
       viewport: viewport.clone({ dontFlip: true }),
     });
 
+    this.#coverSplitLinks(annotations);
+
     await this.annotationLayer.render({
       annotations,
       imageResourcesPath: this.imageResourcesPath,
@@ -180,6 +182,29 @@ class AnnotationLayerBuilder {
       return;
     }
     this.div.hidden = true;
+  }
+
+  // Fixes bug where links were being split into multiple clickable pieces
+  // by increasing the rectangle of one annotation to cover multiple.
+  // For example emails had separate clickable parts for the username and domain
+  #coverSplitLinks(annotations) {
+    for (const [index, annotation] of annotations.entries()) {
+      if (index > 0) {
+        const prev = annotations[index - 1];
+        const prevStart = prev.rect[0];
+        const currentStart = annotation.rect[0];
+        const prevEnd = prev.rect[2];
+        const prevTop = prev.rect[3];
+        const currentTop = annotation.rect[3];
+        if (
+          prev.url === annotation.url &&
+          prevTop === currentTop &&
+          prevEnd === currentStart
+        ) {
+          annotation.rect[0] = prevStart;
+        }
+      }
+    }
   }
 
   #updatePresentationModeState(state) {

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -1029,10 +1029,7 @@ class PDFFindController {
 
     queries = queries.filter(_query => _query.query !== null);
 
-    if (
-      isSentimentHighlight &&
-      pageIndex === this._linkService.pagesCount - 1
-    ) {
+    if (isSentimentHighlight && pageIndex === this._pdfDocument.numPages - 1) {
       this.initializeQueryPageMap(queries);
 
       this.#calculateRegExpMatch(
@@ -1150,7 +1147,24 @@ class PDFFindController {
       setTimeout(() => this.#updatePage(pageIndex), 50);
       this._linkService.goToPage(pageIndex + 1);
     }
+    if (isSentimentHighlight && pageIndex === this._pdfDocument.numPages - 1) {
+      this.updateAllMatches();
+    } else if (!isSentimentHighlight) {
+      this.updateMatches(pageIndex);
+    }
+  }
 
+  updateAllMatches() {
+    for (
+      let pageIndex = 0;
+      pageIndex < this._pdfDocument.numPages;
+      pageIndex++
+    ) {
+      this.updateMatches(pageIndex);
+    }
+  }
+
+  updateMatches(pageIndex) {
     // When `highlightAll` is set, ensure that the matches on previously
     // rendered (and still active) pages are correctly highlighted.
     if (this.#state.highlightAll) {
@@ -1183,7 +1197,7 @@ class PDFFindController {
     });
   }
 
-  dispatchQueryPageMap(pageIndex) {
+  dispatchQueryPageMap() {
     this._eventBus.dispatch("returnQueryPageMap", {
       source: this,
       queryPageMap: this._queryPageMap,

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -1029,7 +1029,10 @@ class PDFFindController {
 
     queries = queries.filter(_query => _query.query !== null);
 
-    if (isSentimentHighlight && pageIndex === 0) {
+    if (
+      isSentimentHighlight &&
+      pageIndex === this._linkService.pagesCount - 1
+    ) {
       this.initializeQueryPageMap(pageIndex, queries);
 
       this.#calculateRegExpMatch(

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -771,6 +771,7 @@ class PDFFindController {
     queries.forEach((q, index) => {
       const query = q.query;
       const color = q.color;
+      let currentStartIndex = 0;
       let startPage = 0;
       let queryFound = false;
 
@@ -799,7 +800,7 @@ class PDFFindController {
 
           const [matchPos, matchLen] = getOriginalIndex(
             diffs,
-            match.index,
+            currentStartIndex + match.index,
             match[0].length
           );
 
@@ -817,6 +818,7 @@ class PDFFindController {
           pageContentsCopy[pageIndex] = pageContentsCopy[pageIndex].slice(
             matchPos + matchLen
           );
+          currentStartIndex = matchPos + matchLen;
           startPage = pageIndex;
           queryFound = true;
         }

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -756,7 +756,6 @@ class PDFFindController {
     if (isSentimentHighlight) {
       this.#calculateRegExpMatchForSentiment(
         queries,
-        pageContent,
         matches,
         matchesLength,
         highlights,
@@ -780,7 +779,6 @@ class PDFFindController {
 
   #calculateRegExpMatchForSentiment(
     queries,
-    pageContent,
     matches,
     matchesLength,
     highlights,
@@ -803,7 +801,7 @@ class PDFFindController {
         }
 
         const diffs = this._pageDiffs[pageIndex];
-        const match = query.exec(pageContent);
+        const match = query.exec(this._pageContents[pageIndex]);
 
         if (match !== null) {
           if (this._queryPageMap[index] === null) {
@@ -1182,12 +1180,10 @@ class PDFFindController {
   }
 
   dispatchQueryPageMap(pageIndex) {
-    if (pageIndex === this._pageContents.length - 1) {
-      this._eventBus.dispatch("returnQueryPageMap", {
-        source: this,
-        queryPageMap: this._queryPageMap,
-      });
-    }
+    this._eventBus.dispatch("returnQueryPageMap", {
+      source: this,
+      queryPageMap: this._queryPageMap,
+    });
   }
 
   #findSubstringMatches(slidingChunks, query, threshold) {

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -767,11 +767,11 @@ class PDFFindController {
     this._pageHighlightsColors = [];
 
     const pageContentsCopy = [...this._pageContents];
+    const pageStartIndices = Array(pageContentsCopy.length).fill(0);
 
     queries.forEach((q, index) => {
       const query = q.query;
       const color = q.color;
-      let currentStartIndex = 0;
       let startPage = 0;
       let queryFound = false;
 
@@ -800,7 +800,7 @@ class PDFFindController {
 
           const [matchPos, matchLen] = getOriginalIndex(
             diffs,
-            currentStartIndex + match.index,
+            pageStartIndices[pageIndex] + match.index,
             match[0].length
           );
 
@@ -818,7 +818,7 @@ class PDFFindController {
           pageContentsCopy[pageIndex] = pageContentsCopy[pageIndex].slice(
             matchPos + matchLen
           );
-          currentStartIndex = matchPos + matchLen;
+          pageStartIndices[pageIndex] = matchPos + matchLen;
           startPage = pageIndex;
           queryFound = true;
         }

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -768,11 +768,11 @@ class PDFFindController {
 
     const pageContentsCopy = [...this._pageContents];
     const pageStartIndices = Array(pageContentsCopy.length).fill(0);
+    let startPage = 0;
 
     queries.forEach((q, index) => {
       const query = q.query;
       const color = q.color;
-      let startPage = 0;
       let queryFound = false;
 
       for (
@@ -815,10 +815,12 @@ class PDFFindController {
             matchLen
           );
 
-          pageContentsCopy[pageIndex] = pageContentsCopy[pageIndex].slice(
-            matchPos + matchLen
+          const offset = pageStartIndices[pageIndex] + match.index - matchPos;
+
+          pageContentsCopy[pageIndex] = this._pageContents[pageIndex].slice(
+            matchPos + matchLen + offset
           );
-          pageStartIndices[pageIndex] = matchPos + matchLen;
+          pageStartIndices[pageIndex] = matchPos + matchLen + offset;
           startPage = pageIndex;
           queryFound = true;
         }

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -804,8 +804,6 @@ class PDFFindController {
           );
 
           this.#handleMatch(
-            diffs,
-            match,
             color,
             matches,
             matchesLength,
@@ -859,8 +857,6 @@ class PDFFindController {
         );
 
         this.#handleMatch(
-          diffs,
-          match,
           color,
           matches,
           matchesLength,

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -775,11 +775,11 @@ class PDFFindController {
           continue;
         }
 
-        const matches = (this._pageMatches[pageIndex] = []);
-        const matchesLength = (this._pageMatchesLength[pageIndex] = []);
-        const highlights = (this._pageHighlights[pageIndex] = []);
-        const highlightsLength = (this._pageHighlightsLength[pageIndex] = []);
-        const highlightsColors = (this._pageHighlightsColors[pageIndex] = []);
+        const matches = (this._pageMatches[pageIndex] ??= []);
+        const matchesLength = (this._pageMatchesLength[pageIndex] ??= []);
+        const highlights = (this._pageHighlights[pageIndex] ??= []);
+        const highlightsLength = (this._pageHighlightsLength[pageIndex] ??= []);
+        const highlightsColors = (this._pageHighlightsColors[pageIndex] ??= []);
 
         const diffs = this._pageDiffs[pageIndex];
         const match = query.exec(this._pageContents[pageIndex]);

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -741,12 +741,6 @@ class PDFFindController {
     pageContent,
     isSentimentHighlight
   ) {
-    const matches = (this._pageMatches[pageIndex] = []);
-    const matchesLength = (this._pageMatchesLength[pageIndex] = []);
-    const highlights = (this._pageHighlights[pageIndex] = []);
-    const highlightsLength = (this._pageHighlightsLength[pageIndex] = []);
-    const highlightsColors = (this._pageHighlightsColors[pageIndex] = []);
-
     if (!queries.length) {
       // The query can be empty because some chars like diacritics could have
       // been stripped out.
@@ -754,37 +748,18 @@ class PDFFindController {
     }
 
     if (isSentimentHighlight) {
-      this.#calculateRegExpMatchForSentiment(
-        queries,
-        matches,
-        matchesLength,
-        highlights,
-        highlightsLength,
-        highlightsColors
-      );
+      this.#calculateRegExpMatchForSentiment(queries);
     } else {
       this.#calculateRegExpMatchForHighlightAll(
         queries,
         entireWord,
         pageIndex,
-        pageContent,
-        matches,
-        matchesLength,
-        highlights,
-        highlightsLength,
-        highlightsColors
+        pageContent
       );
     }
   }
 
-  #calculateRegExpMatchForSentiment(
-    queries,
-    matches,
-    matchesLength,
-    highlights,
-    highlightsLength,
-    highlightsColors
-  ) {
+  #calculateRegExpMatchForSentiment(queries) {
     queries.forEach((q, index) => {
       const query = q.query;
       const color = q.color;
@@ -799,6 +774,12 @@ class PDFFindController {
         if (queryFound) {
           continue;
         }
+
+        const matches = (this._pageMatches[pageIndex] = []);
+        const matchesLength = (this._pageMatchesLength[pageIndex] = []);
+        const highlights = (this._pageHighlights[pageIndex] = []);
+        const highlightsLength = (this._pageHighlightsLength[pageIndex] = []);
+        const highlightsColors = (this._pageHighlightsColors[pageIndex] = []);
 
         const diffs = this._pageDiffs[pageIndex];
         const match = query.exec(this._pageContents[pageIndex]);
@@ -830,13 +811,14 @@ class PDFFindController {
     queries,
     entireWord,
     pageIndex,
-    pageContent,
-    matches,
-    matchesLength,
-    highlights,
-    highlightsLength,
-    highlightsColors
+    pageContent
   ) {
+    const matches = (this._pageMatches[pageIndex] = []);
+    const matchesLength = (this._pageMatchesLength[pageIndex] = []);
+    const highlights = (this._pageHighlights[pageIndex] = []);
+    const highlightsLength = (this._pageHighlightsLength[pageIndex] = []);
+    const highlightsColors = (this._pageHighlightsColors[pageIndex] = []);
+
     const diffs = this._pageDiffs[pageIndex];
     let match;
 

--- a/web/pdf_find_controller.js
+++ b/web/pdf_find_controller.js
@@ -1033,7 +1033,7 @@ class PDFFindController {
       isSentimentHighlight &&
       pageIndex === this._linkService.pagesCount - 1
     ) {
-      this.initializeQueryPageMap(pageIndex, queries);
+      this.initializeQueryPageMap(queries);
 
       this.#calculateRegExpMatch(
         queries,
@@ -1177,12 +1177,10 @@ class PDFFindController {
     }
   }
 
-  initializeQueryPageMap(pageIndex, queries) {
-    if (pageIndex === 0) {
-      queries.forEach((_, index) => {
-        this._queryPageMap[index] = null;
-      });
-    }
+  initializeQueryPageMap(queries) {
+    queries.forEach((_, index) => {
+      this._queryPageMap[index] = null;
+    });
   }
 
   dispatchQueryPageMap(pageIndex) {

--- a/web/text_highlighter.js
+++ b/web/text_highlighter.js
@@ -178,7 +178,7 @@ class TextHighlighter {
     function styleSpan(span, backgroundColor) {
       span.style.background = backgroundColor ?? "rgba(0 166 255 / 0.25)"; // backgroundColor is converted to rgb or rgba automatically
       if (span.className.includes("selected")) {
-        setAlpha(span, ".50)"); // Highlight selected term with original color but more opacity
+        setAlpha(span, ".5"); // Highlight selected term with original color but more opacity
       } else {
         setAlpha(span); // Override alpha value to ensure we have appropriate opacity on highlights
       }
@@ -187,7 +187,7 @@ class TextHighlighter {
       span.style.webkitTransform = "";
     }
 
-    function setAlpha(span, alpha = ".25)") {
+    function setAlpha(span, alpha = ".25") {
       const backgroundElements = span.style.background
         .split(",")
         .slice(0, 3)

--- a/web/text_highlighter.js
+++ b/web/text_highlighter.js
@@ -183,6 +183,7 @@ class TextHighlighter {
         setAlpha(span); // Override alpha value to ensure we have appropriate opacity on highlights
       }
       span.style.borderRadius = "0";
+      span.style.transform = "";
       span.style.webkitTransform = "";
     }
 
@@ -209,9 +210,9 @@ class TextHighlighter {
         toOffset
       );
       const node = document.createTextNode(content);
-      if (className || bgColor) {
-        const span = document.createElement("span");
+      const span = document.createElement("span");
 
+      if (className || bgColor) {
         if (className) {
           span.className = `${className} appended`;
         }
@@ -222,7 +223,10 @@ class TextHighlighter {
         div.append(span);
         return className.includes("selected") ? span.offsetLeft : 0;
       }
-      div.append(node);
+      styleSpan(span, bgColor);
+
+      span.append(node);
+      div.append(span);
       return 0;
     }
 

--- a/web/text_highlighter.js
+++ b/web/text_highlighter.js
@@ -183,7 +183,6 @@ class TextHighlighter {
         setAlpha(span); // Override alpha value to ensure we have appropriate opacity on highlights
       }
       span.style.borderRadius = "0";
-      span.style.transform = "";
       span.style.webkitTransform = "";
     }
 
@@ -210,9 +209,9 @@ class TextHighlighter {
         toOffset
       );
       const node = document.createTextNode(content);
-      const span = document.createElement("span");
-
       if (className || bgColor) {
+        const span = document.createElement("span");
+
         if (className) {
           span.className = `${className} appended`;
         }
@@ -223,10 +222,7 @@ class TextHighlighter {
         div.append(span);
         return className.includes("selected") ? span.offsetLeft : 0;
       }
-      styleSpan(span, bgColor);
-
-      span.append(node);
-      div.append(span);
+      div.append(node);
       return 0;
     }
 

--- a/web/text_highlighter.js
+++ b/web/text_highlighter.js
@@ -182,6 +182,8 @@ class TextHighlighter {
       } else {
         setAlpha(span); // Override alpha value to ensure we have appropriate opacity on highlights
       }
+      span.style.margin = "-1px";
+      span.style.padding = "1px";
       span.style.borderRadius = "0";
     }
 

--- a/web/text_highlighter.js
+++ b/web/text_highlighter.js
@@ -183,6 +183,7 @@ class TextHighlighter {
         setAlpha(span); // Override alpha value to ensure we have appropriate opacity on highlights
       }
       span.style.borderRadius = "0";
+      span.style.webkitTransform = "";
     }
 
     function setAlpha(span, alpha = ".25)") {
@@ -215,9 +216,7 @@ class TextHighlighter {
           span.className = `${className} appended`;
         }
 
-        if (bgColor || className.includes("selected")) {
-          styleSpan(span, bgColor);
-        }
+        styleSpan(span, bgColor);
 
         span.append(node);
         div.append(span);

--- a/web/text_highlighter.js
+++ b/web/text_highlighter.js
@@ -178,7 +178,7 @@ class TextHighlighter {
     function styleSpan(span, backgroundColor) {
       span.style.background = backgroundColor ?? "rgba(0 166 255 / 0.25)"; // backgroundColor is converted to rgb or rgba automatically
       if (span.className.includes("selected")) {
-        setAlpha(span, ".5"); // Highlight selected term with original color but more opacity
+        setAlpha(span, ".50)"); // Highlight selected term with original color but more opacity
       } else {
         setAlpha(span); // Override alpha value to ensure we have appropriate opacity on highlights
       }
@@ -187,7 +187,7 @@ class TextHighlighter {
       span.style.borderRadius = "0";
     }
 
-    function setAlpha(span, alpha = ".25") {
+    function setAlpha(span, alpha = ".25)") {
       const backgroundElements = span.style.background
         .split(",")
         .slice(0, 3)

--- a/web/text_highlighter.js
+++ b/web/text_highlighter.js
@@ -183,7 +183,6 @@ class TextHighlighter {
         setAlpha(span); // Override alpha value to ensure we have appropriate opacity on highlights
       }
       span.style.borderRadius = "0";
-      span.style.webkitTransform = "";
     }
 
     function setAlpha(span, alpha = ".25)") {
@@ -216,7 +215,9 @@ class TextHighlighter {
           span.className = `${className} appended`;
         }
 
-        styleSpan(span, bgColor);
+        if (bgColor || className.includes("selected")) {
+          styleSpan(span, bgColor);
+        }
 
         span.append(node);
         div.append(span);

--- a/web/text_highlighter.js
+++ b/web/text_highlighter.js
@@ -178,7 +178,7 @@ class TextHighlighter {
     function styleSpan(span, backgroundColor) {
       span.style.background = backgroundColor ?? "rgba(0 166 255 / 0.25)"; // backgroundColor is converted to rgb or rgba automatically
       if (span.className.includes("selected")) {
-        setAlpha(span, ".5"); // Highlight selected term with original color but more opacity
+        setAlpha(span, ".50)"); // Highlight selected term with original color but more opacity
       } else {
         setAlpha(span); // Override alpha value to ensure we have appropriate opacity on highlights
       }
@@ -187,7 +187,7 @@ class TextHighlighter {
       span.style.webkitTransform = "";
     }
 
-    function setAlpha(span, alpha = ".25") {
+    function setAlpha(span, alpha = ".25)") {
       const backgroundElements = span.style.background
         .split(",")
         .slice(0, 3)

--- a/web/text_highlighter.js
+++ b/web/text_highlighter.js
@@ -182,8 +182,6 @@ class TextHighlighter {
       } else {
         setAlpha(span); // Override alpha value to ensure we have appropriate opacity on highlights
       }
-      span.style.margin = "-1px";
-      span.style.padding = "1px";
       span.style.borderRadius = "0";
     }
 

--- a/web/text_layer_builder.css
+++ b/web/text_layer_builder.css
@@ -61,6 +61,8 @@
       );
     }
 
+    margin: -1px;
+    padding: 1px;
     background-color: var(--highlight-bg-color);
     backdrop-filter: var(--highlight-backdrop-filter);
     border-radius: 4px;
@@ -69,9 +71,15 @@
       position: initial;
     }
 
-    &.begin,
-    &.middle,
+    &.begin {
+      border-radius: 4px 0 0 4px;
+    }
+
     &.end {
+      border-radius: 0 4px 4px 0;
+    }
+
+    &.middle {
       border-radius: 0;
     }
 

--- a/web/text_layer_builder.css
+++ b/web/text_layer_builder.css
@@ -61,8 +61,6 @@
       );
     }
 
-    margin: -1px;
-    padding: 1px;
     background-color: var(--highlight-bg-color);
     backdrop-filter: var(--highlight-backdrop-filter);
     border-radius: 4px;
@@ -71,15 +69,9 @@
       position: initial;
     }
 
-    &.begin {
-      border-radius: 4px 0 0 4px;
-    }
-
+    &.begin,
+    &.middle,
     &.end {
-      border-radius: 0 4px 4px 0;
-    }
-
-    &.middle {
       border-radius: 0;
     }
 

--- a/web/text_layer_builder.css
+++ b/web/text_layer_builder.css
@@ -86,7 +86,6 @@
     &.selected {
       background-color: background;
       backdrop-filter: var(--highlight-selected-backdrop-filter);
-      box-shadow: 2px 2px darkgrey;
     }
   }
 


### PR DESCRIPTION
These changes cover a number of PDFjs related bug tickets from QA.
- RC-23343: The requested behavior is for links in pdf documents not to be clickable from the viewer. This undoes some previous changes
- RC-21855: Removes the box-shadow from selected sentiment highlights
- RC-23455: Addresses multiple sentiment highlighting bugs
  - Issues when a document had the same sentiment sentence appear multiple times in the text
  - Issues switching between documents while highlighting is toggled on